### PR TITLE
bxcan: can_enable(): fix disabling of standby pin

### DIFF
--- a/src/can.c
+++ b/src/can.c
@@ -124,7 +124,7 @@ void can_enable(can_data_t *hcan, bool loop_back, bool listen_only, bool one_sho
 	can->FMR &= ~CAN_FMR_FINIT;
 
 #ifdef nCANSTBY_Pin
-	HAL_GPIO_WritePin(nCANSTBY_Port, nCANSTBY_Pin, ~GPIO_INIT_STATE(nCANSTBY_Active_High));
+	HAL_GPIO_WritePin(nCANSTBY_Port, nCANSTBY_Pin, !GPIO_INIT_STATE(nCANSTBY_Active_High));
 #endif
 }
 


### PR DESCRIPTION
The binary inverse of 0x1 is 0xfe not 0x0. Fix this by using a logic negation instead.

Fixes: f4f1586dbf56 ("can.c: use GPIO_INIT_STATE to set CANSTBY pin")