### PR TITLE
openocd.cfg: remove commented out statement and fix deprecation warning

### DIFF
--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,7 +1,4 @@
-
-#source [find board/stm32f0discovery.cfg]
-
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 transport select hla_swd
 source [find target/stm32f0x.cfg]
 
@@ -11,4 +8,3 @@ reset_config srst_only
 
 #init
 #reset init
-


### PR DESCRIPTION
```
WARNING: interface/stlink-v2.cfg is deprecated, please switch to interface/stlink.cfg
```