### PR TITLE
gs_usb: ensure RX endpoint buffer is prepared with interrupts disabled.

### DIFF
--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -774,9 +774,9 @@ void USBD_GS_CAN_ReceiveFromHost(USBD_HandleTypeDef *pdev)
 	}
 
 	list_del(&hcan->from_host_buf->list);
-	restore_irq(was_irq_enabled);
 
 	USBD_GS_CAN_PrepareReceive(pdev);
+	restore_irq(was_irq_enabled);
 }
 
 static uint8_t USBD_GS_CAN_Transmit(USBD_HandleTypeDef *pdev, uint8_t *buf, uint16_t len)


### PR DESCRIPTION
This avoids writing the received USB frames from the host in a wrong msgbuf.

Fixes https://github.com/candle-usb/candleLight_fw/issues/211