### PR TITLE
libs/STM32_HAL: disable instruction prefetch for STM32G0XX.

### DIFF
--- a/libs/STM32_HAL/config/stm32g0xx_hal_conf.h
+++ b/libs/STM32_HAL/config/stm32g0xx_hal_conf.h
@@ -178,7 +178,7 @@ in voltage and temperature.*/
 #define  VDD_VALUE                    (3300UL)                                        /*!< Value of VDD in mv */
 #define  TICK_INT_PRIORITY            3U /*!< tick interrupt priority */
 #define  USE_RTOS                     0U
-#define  PREFETCH_ENABLE              1U
+#define  PREFETCH_ENABLE              0U
 #define  INSTRUCTION_CACHE_ENABLE     1U
 
 /* ################## SPI peripheral configuration ########################## */


### PR DESCRIPTION
STM32G0xx MCUs have a known errata which causes wrong instruction execution when branching across memory banks.

Although different subfamilies of STM32G0xx have separate errata sheets, this seems to be present on the whole range of devices; the errata is declared for all the family members having multiple Flash banks:

- [STM32G070CB/KB/RB device errata](https://www.st.com/resource/en/errata_sheet/es0468-stm32g070cbkbrb-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g070cb.pdf))
- [STM32G071x8/xB device errata](https://www.st.com/resource/en/errata_sheet/es0418-stm32g071x8xb-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g071c8.pdf))
- [STM32G081xB device errata](https://www.st.com/resource/en/errata_sheet/es0412-stm32g081xb-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g081cb.pdf))
- [STM32G041x6/x8 device errata](https://www.st.com/resource/en/errata_sheet/es0488-stm32g041x6x8-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g041c8.pdf))
- [STM32G031x4/x6/x8 device errata](https://www.st.com/resource/en/errata_sheet/es0487-stm32g031x4x6x8-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g031c6.pdf))
- [STM32G030x6/x8 device errata](https://www.st.com/resource/en/errata_sheet/es0486-stm32g030x6x8-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g030c6.pdf))
- [STM32G0B0CE/KE/RE/VE device errata](https://www.st.com/resource/en/errata_sheet/es0547-stm32g0b0cekereve-device-errata-stmicroelectronics.pdf) (section 2.2.8)
- [STM32G0B1xB/xC/xE device errata](https://www.st.com/resource/en/errata_sheet/es0548-stm32g0b1xbxcxe-device-errata-stmicroelectronics.pdf) (section 2.2.10)
- [STM32G0C1xC/xE device errata](https://www.st.com/resource/en/errata_sheet/es0549-stm32g0c1xcxe-device-errata-stmicroelectronics.pdf) (section 2.2.10)
- [STM32G061x6/x8 device errata](https://www.st.com/resource/en/errata_sheet/es0546-stm32g061x6x8-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g061c6.pdf))
- [STM32G051x6/x8 device errata](https://www.st.com/resource/en/errata_sheet/es0545-stm32g051x6x8-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g051c6.pdf))
- [STM32G050x6/x8 device errata](https://www.st.com/resource/en/errata_sheet/es0544-stm32g050x6x8-device-errata-stmicroelectronics.pdf) (no dual Flash banks, [datasheet](https://www.st.com/resource/en/datasheet/stm32g050c6.pdf))

There is no known workaround. The recommended action is either restricting code to be on just one memory bank, or disable the prefetch, which this PR does.