### PR TITLE
version: include version.h only in usbd_desc.c

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -38,8 +38,6 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "version.h"
-
 #define CAN_QUEUE_SIZE				 (64 * NUM_CAN_CHANNEL)
 
 #define USBD_VID					 0x1d50

--- a/src/usbd_desc.c
+++ b/src/usbd_desc.c
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "usbd_ctlreq.h"
 #include "usbd_desc.h"
 #include "util.h"
+#include "version.h"
 
 static uint8_t *USBD_FS_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
 static uint8_t *USBD_FS_LangIDStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);


### PR DESCRIPTION
When rebasing the git version changes quite often, thus the version.h. By only including it in `usbd_desc.c`, where it is actually needed speeds up incremental builds. This also increases the hit rate for `ccache`.