### PR TITLE
usbd_gs_can: USBD_GS_CAN_SendToHost(): return untransmitted message back to transmit queue, rather than free queue

### DIFF
--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -897,7 +897,7 @@ void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev)
 		return;
 
 	was_irq_enabled = disable_irq();
-	list_add(&hcan->to_host_buf->list, &hcan->list_frame_pool);
+	list_add(&hcan->to_host_buf->list, &hcan->list_to_host);
 	hcan->to_host_buf = NULL;
 	restore_irq(was_irq_enabled);
 }


### PR DESCRIPTION
Fixes: f418aa362c5c ("usbd_gs_can: clean up send to host path")