### PR TITLE
Revert "gs_usb: reserve pre-allocated RX buffers"

### DIFF
--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -65,14 +65,7 @@ extern USBD_ClassTypeDef USBD_GS_CAN;
 #define GS_HOST_FRAME_SIZE struct_size((struct gs_host_frame *)NULL, classic_can_ts, 1)
 #endif
 
-// When using double buffer for RX, this needs to be at least 2 to
-// ensure there is always an RX buffer ready to receive the
-// RX frames.
-#if defined(USB) || defined(USB_DRD_FS)
-#define USBD_GS_CAN_RX_BUFFER_COUNT 2
-#else
 #define USBD_GS_CAN_RX_BUFFER_COUNT 1
-#endif
 
 struct gs_host_frame_object {
 	struct list_head list;


### PR DESCRIPTION
This reverts commit 6f6c14ec8cb7a8c12c896b4de3a401989ac93a85.

With commit 6f6c14ec8cb7 ("gs_usb: reserve pre-allocated RX buffers") TX on stm32f072 stops after ~30 CAN frames [1]. On stmg0b1 completely stops working. Revert for now.

[1] https://github.com/candle-usb/candleLight_fw/issues/218