### PR TITLE
gs_usb: avoid continously reconfiguring USB reception.

### DIFF
--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -614,13 +614,16 @@ static uint8_t USBD_GS_CAN_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 }
 
 // Prefill the buffers from RX from host.
-// Return true if managed to fill the pre-allocate buffer list
-// and RX can be enabled, false otherwise.
+// Return true if pre-allocated buffer list buffer list
+// was changed and is now ready, meaning and RX can be
+// re-enabled, false otherwise.
 // Must be called with IRQ disabled.
 static bool USBD_GS_Prefill_RX_Buffers(USBD_GS_CAN_HandleTypeDef *hcan)
 {
 	unsigned i;
+	bool changed;
 
+	changed = false;
 	for (i = 0; i < ARRAY_SIZE(hcan->from_host_buf); ++i) {
 		if (hcan->from_host_buf[i])
 			continue;
@@ -632,9 +635,11 @@ static bool USBD_GS_Prefill_RX_Buffers(USBD_GS_CAN_HandleTypeDef *hcan)
 			return false;
 
 		list_del(&hcan->from_host_buf[i]->list);
+
+		changed = true;
 	}
 
-	return true;
+	return changed;
 }
 
 // Note that the return value is completely ignored by the stack.


### PR DESCRIPTION
There was a mistake in https://github.com/candle-usb/candleLight_fw/pull/209 causing USBD_GS_CAN_PrepareReceive to be called periodically from USBD_GS_CAN_ReceiveFromHost, even when all the buffers were already allocated and therefore USB HW might be in the middle of a reception.

This change makes USBD_GS_CAN_PrepareReceive only be called when buffers *were not allocated* (meaning endpoint was disabled) and they have been allocated new.

Fixes: https://github.com/candle-usb/candleLight_fw/issues/218
Needs to be applied on top of https://github.com/candle-usb/candleLight_fw/pull/209, which was reverted in https://github.com/candle-usb/candleLight_fw/pull/222
Then, this also fixes https://github.com/candle-usb/candleLight_fw/issues/207
