### PR TITLE
disable LTO for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 add_compile_options(
 	$<$<CONFIG:Release>:-flto>
-	$<$<CONFIG:Release>:-ffat-lto-objects>
+	$<$<CONFIG:Release>:-fno-fat-lto-objects>
 	--specs=nano.specs
 	--specs=nosys.specs
 	-O2


### PR DESCRIPTION
Enable LTO for Release builds and enable Release builds by default. Also switch from fat LTO objects to no-fat. This slightly decreases build time.