### PR TITLE
Port AMD xHCI composite device enumeration fixes

### DIFF
--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -52,7 +52,7 @@ THE SOFTWARE.
 #else
 #define CAN_DATA_MAX_PACKET_SIZE 32    /* Endpoint IN & OUT Packet size */
 #endif
-#define USB_CAN_CONFIG_DESC_SIZ	 50
+#define USB_CAN_CONFIG_DESC_SIZ	 58  /* 50 base + 8 for IAD */
 #define USBD_GS_CAN_VENDOR_CODE	 0x20
 #define DFU_INTERFACE_NUM		 1
 #define DFU_INTERFACE_STR_INDEX	 0xE0

--- a/libs/STM32_HAL/stm32f0xx-hal-driver/Src/stm32f0xx_hal_pcd.c
+++ b/libs/STM32_HAL/stm32f0xx-hal-driver/Src/stm32f0xx_hal_pcd.c
@@ -1470,7 +1470,16 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   ep->is_in = 0U;
   ep->num = ep_addr & EP_ADDR_MSK;
 
+  /* USER CODE BEGIN HAL_PCD_EP_Receive_Concurrency_Fix */
+  /* WARNING: Disable USB IRQ to prevent HAL_PCD_EP_Receive and
+   * HAL_PCD_EP_Transmit from preempting each other, avoiding
+   * USBD_BUSY deadlocks on AMD xHCI controllers.
+   * Ref: https://community.st.com/t5/stm32-mcus-embedded-software/usb-cdc-device-receive-fails-on-transmit/td-p/472929
+   * WARNING: STM32CubeMX will overwrite this file; reapply this fix. */
+  HAL_NVIC_DisableIRQ(USB_IRQn);
   (void)USB_EPStartXfer(hpcd->Instance, ep);
+  HAL_NVIC_EnableIRQ(USB_IRQn);
+  /* USER CODE END HAL_PCD_EP_Receive_Concurrency_Fix */
 
   return HAL_OK;
 }
@@ -1508,7 +1517,16 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   ep->is_in = 1U;
   ep->num = ep_addr & EP_ADDR_MSK;
 
+  /* USER CODE BEGIN HAL_PCD_EP_Transmit_Concurrency_Fix */
+  /* WARNING: Disable USB IRQ to prevent HAL_PCD_EP_Transmit and
+   * HAL_PCD_EP_Receive from preempting each other, avoiding
+   * USBD_BUSY deadlocks on AMD xHCI controllers.
+   * Ref: https://community.st.com/t5/stm32-mcus-embedded-software/usb-cdc-device-receive-fails-on-transmit/td-p/472929
+   * WARNING: STM32CubeMX will overwrite this file; reapply this fix. */
+  HAL_NVIC_DisableIRQ(USB_IRQn);
   (void)USB_EPStartXfer(hpcd->Instance, ep);
+  HAL_NVIC_EnableIRQ(USB_IRQn);
+  /* USER CODE END HAL_PCD_EP_Transmit_Concurrency_Fix */
 
   return HAL_OK;
 }

--- a/src/usbd_desc.c
+++ b/src/usbd_desc.c
@@ -59,9 +59,12 @@ static const uint8_t USBD_FS_DeviceDesc[USB_LEN_DEV_DESC] = {
 	USB_DESC_TYPE_DEVICE,       /* bDescriptorType */
 	0x00,                       /* bcdUSB */
 	0x02,
-	0x00,                       /* bDeviceClass */
-	0x00,                       /* bDeviceSubClass */
-	0x00,                       /* bDeviceProtocol */
+	/* WARNING: Class 0xEF/0x02/0x01 (Misc/Common/IAD) is required for
+	 * composite device enumeration. Without this, AMD xHCI controllers
+	 * fail to split interfaces into separate child devices. */
+	0xEF,                       /* bDeviceClass: Miscellaneous */
+	0x02,                       /* bDeviceSubClass: Common Class */
+	0x01,                       /* bDeviceProtocol: IAD */
 	USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
 	LOBYTE(USBD_VID),           /* idVendor */
 	HIBYTE(USBD_VID),

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -46,6 +46,24 @@ THE SOFTWARE.
 
 static volatile bool is_usb_suspend_cb = false;
 
+static uint8_t *USBD_GS_CAN_GetDeviceQualifierDesc(uint16_t *length);
+
+/* WARNING: GetDeviceQualifierDescriptor callback MUST NOT be NULL.
+ * STM32 USB library zero-initializes dev_speed to USBD_SPEED_HIGH (0).
+ * Before HAL_PCD_ResetCallback sets speed to FULL, a Device Qualifier
+ * request will call this callback; if NULL, the device hard-faults. */
+__ALIGN_BEGIN static uint8_t USBD_GS_CAN_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END = {
+	USB_LEN_DEV_QUALIFIER_DESC,       /* bLength */
+	USB_DESC_TYPE_DEVICE_QUALIFIER,   /* bDescriptorType */
+	0x00, 0x02,                       /* bcdUSB: USB 2.0 */
+	0x00,                             /* bDeviceClass */
+	0x00,                             /* bDeviceSubClass */
+	0x00,                             /* bDeviceProtocol */
+	USB_MAX_EP0_SIZE,                 /* bMaxPacketSize0 */
+	0x01,                             /* bNumConfigurations */
+	0x00,                             /* bReserved */
+};
+
 /* Configuration Descriptor */
 static const uint8_t USBD_GS_CAN_CfgDesc[USB_CAN_CONFIG_DESC_SIZ] =
 {
@@ -60,6 +78,21 @@ static const uint8_t USBD_GS_CAN_CfgDesc[USB_CAN_CONFIG_DESC_SIZ] =
 	USBD_IDX_CONFIG_STR,              /* iConfiguration */
 	0x80,                             /* bmAttributes */
 	0x4B,                             /* MaxPower 150 mA */
+	/*---------------------------------------------------------------------------*/
+
+	/*---------------------------------------------------------------------------*/
+	/* WARNING: IAD is required for composite device enumeration on AMD
+	 * xHCI controllers. bInterfaceCount MUST be 1 (gs_usb only).
+	 * If set to 2, Windows groups both interfaces into one function,
+	 * resulting in Code 28 "no driver" and no DFU device. */
+	0x08,                             /* bLength */
+	0x0B,                             /* bDescriptorType: IAD */
+	0x00,                             /* bFirstInterface */
+	0x01,                             /* bInterfaceCount */
+	0xFF,                             /* bFunctionClass: Vendor Specific */
+	0xFF,                             /* bFunctionSubClass: Vendor Specific */
+	0xFF,                             /* bFunctionProtocol: Vendor Specific */
+	0x00,                             /* iFunction */
 	/*---------------------------------------------------------------------------*/
 
 	/*---------------------------------------------------------------------------*/
@@ -135,23 +168,17 @@ static const uint8_t USBD_GS_CAN_WINUSB_STR[] =
 	0x00                     /* padding */
 };
 
-/*  Microsoft Compatible ID Feature Descriptor  */
+/* WARNING: Only 1 section mapping interface 0 to WINUSB. Do NOT add a
+ * WINUSB section for interface 1 (DFU); doing so prevents Windows from
+ * assigning the DFU class driver, and the DFU device will not appear. */
 static const uint8_t USBD_MS_COMP_ID_FEATURE_DESC[] = {
-	0x40, 0x00, 0x00, 0x00, /* length */
+	0x28, 0x00, 0x00, 0x00, /* length */
 	0x00, 0x01,             /* version 1.0 */
 	0x04, 0x00,             /* descr index (0x0004) */
-	0x02,                   /* number of sections */
+	0x01,                   /* number of sections */
 	0x00, 0x00, 0x00, 0x00, /* reserved */
 	0x00, 0x00, 0x00,
 	0x00,                   /* interface number */
-	0x01,                   /* reserved */
-	0x57, 0x49, 0x4E, 0x55, /* compatible ID ("WINUSB\0\0") */
-	0x53, 0x42, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, /* sub-compatible ID */
-	0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, /* reserved */
-	0x00, 0x00,
-	0x01,                   /* interface number */
 	0x01,                   /* reserved */
 	0x57, 0x49, 0x4E, 0x55, /* compatible ID ("WINUSB\0\0") */
 	0x53, 0x42, 0x00, 0x00,
@@ -476,12 +503,20 @@ static uint8_t USBD_GS_CAN_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef 
 					break;
 
 				case USB_REQ_SET_INTERFACE:
+					break;
+
 				default:
+					/* WARNING: Must STALL unknown standard requests
+					 * for Windows enumeration on AMD xHCI. */
+					USBD_CtlError(pdev, req);
 					break;
 			}
 			break;
 
 		default:
+			/* WARNING: Must STALL unhandled request types
+			 * for Windows enumeration on AMD xHCI. */
+			USBD_CtlError(pdev, req);
 			break;
 	}
 	return USBD_OK;
@@ -750,6 +785,12 @@ uint8_t *USBD_GS_CAN_GetStrDesc(USBD_HandleTypeDef *pdev, uint8_t index, uint16_
 	}
 }
 
+static uint8_t *USBD_GS_CAN_GetDeviceQualifierDesc(uint16_t *length)
+{
+	*length = sizeof(USBD_GS_CAN_DeviceQualifierDesc);
+	return USBD_GS_CAN_DeviceQualifierDesc;
+}
+
 /* CAN interface class callbacks structure */
 USBD_ClassTypeDef USBD_GS_CAN = {
 	.Init = USBD_GS_CAN_Start,
@@ -762,6 +803,7 @@ USBD_ClassTypeDef USBD_GS_CAN = {
 	.GetHSConfigDescriptor = USBD_GS_CAN_GetCfgDesc,
 	.GetFSConfigDescriptor = USBD_GS_CAN_GetCfgDesc,
 	.GetOtherSpeedConfigDescriptor = USBD_GS_CAN_GetCfgDesc,
+	.GetDeviceQualifierDescriptor = USBD_GS_CAN_GetDeviceQualifierDesc,
 	.GetUsrStrDescriptor = USBD_GS_CAN_GetStrDesc,
 };
 
@@ -793,6 +835,10 @@ bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqType
 
 		}
 
+		/* WARNING: Must STALL unrecognized vendor requests.
+		 * Windows enumeration fails without this. */
+		USBD_CtlError(pdev, req);
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
Hi, I was unable to detect my fysetc uscan device on a computer with AMD xHCI USB .

I was able to fix that issue in https://github.com/BenGardiner/ucan_cantact_fw/pull/1

I wanted to help this project in case anyone else is running into problems using these STM32 candle firmware devices on AMD xHCI USD. But I apologize I have never been able to use this project as firmware in my fysetc device. So I ported the changes that I know work to this commit. 

My apologies but these changes are untested (I have never been able to use this project as firmware in my fysetc device).