### PR TITLE
cleanup EP0 buffer size calculation

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -115,19 +115,7 @@
 		__struct_group(_tag, _name, /* no attrs */, _members)
 #endif
 
-#define min(x, y)			   ((x) < (y) ? (x) : (y))
-#define max(x, y)			   ((x) > (y) ? (x) : (y))
-
-#define min3(a, b, c)		   min(a, min(b, c))
-#define max3(a, b, c)		   max(a, max(b, c))
-
-#define min4(a, b, c, d)	   min(min(a, b), min(c, d))
-#define max4(a, b, c, d)	   max(max(a, b), max(c, d))
-
-#define min5(a, b, c, d, e)	   min3(min(a, b), min(c, d), e)
-#define max5(a, b, c, d, e)	   max3(max(a, b), max(c, d), e)
-
-#define min6(a, b, c, d, e, f) min3(min(a, b), min(c, d), min(e, f))
-#define max6(a, b, c, d, e, f) max3(max(a, b), max(c, d), max(e, f))
+#define min(x, y) ((x) < (y) ? (x) : (y))
+#define max(x, y) ((x) > (y) ? (x) : (y))
 
 #endif /* _LINUXKPI_LINUX_COMPILER_H_ */

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -97,6 +97,24 @@
 			_t _n[0]; \
 		}
 
+#ifndef __struct_group
+#define __struct_group(_tag, _name, _attrs, _members ...) \
+		union { \
+			struct { _members } _attrs; \
+			struct _tag { _members } _attrs _name; \
+		} _attrs
+#endif
+
+#ifndef struct_group
+#define struct_group(_name, _members ...) \
+		__struct_group(/* no tag */, _name, /* no attrs */, _members)
+#endif
+
+#ifndef struct_group_tagged
+#define struct_group_tagged(_tag, _name, _members ...) \
+		__struct_group(_tag, _name, /* no attrs */, _members)
+#endif
+
 #define min(x, y)			   ((x) < (y) ? (x) : (y))
 #define max(x, y)			   ((x) > (y) ? (x) : (y))
 

--- a/include/dfu.h
+++ b/include/dfu.h
@@ -26,4 +26,13 @@ THE SOFTWARE.
 
 #pragma once
 
+#include <stdint.h>
+
+struct dfu_status {
+	uint8_t status;
+	uint8_t poll_timeout[3];
+	uint8_t state;
+	uint8_t stringidx;
+};
+
 void dfu_run_bootloader(void);

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -223,9 +223,9 @@ enum gs_can_state {
 };
 
 enum gs_can_termination_state {
-	GS_CAN_TERMINATION_UNSUPPORTED = -1,    // private, not in kernel enum
 	GS_CAN_TERMINATION_STATE_OFF = 0,
 	GS_CAN_TERMINATION_STATE_ON,
+	GS_CAN_TERMINATION_UNSUPPORTED = 0xffffffff,    // private, not in kernel enum
 };
 
 enum gs_device_filter_dev {

--- a/include/usbd_dfu.h
+++ b/include/usbd_dfu.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief USB Device Firmware Upgrade (DFU) public header
+ *
+ * Header exposes API for registering DFU images.
+ */
+
+#ifndef ZEPHYR_INCLUDE_USB_CLASS_USBD_DFU_H
+#define ZEPHYR_INCLUDE_USB_CLASS_USBD_DFU_H
+
+#include <stdint.h>
+
+#include "compiler.h"
+
+/* DFU Class Subclass */
+#define USB_DFU_SUBCLASS 0x01
+
+/* DFU Class runtime Protocol */
+#define USB_DFU_PROTOCOL_RUNTIME 0x01
+
+/* DFU Class DFU mode Protocol */
+#define USB_DFU_PROTOCOL_DFU 0x02
+
+/* DFU Class Specific Requests */
+#define USB_DFU_REQ_DETACH	  0x00
+#define USB_DFU_REQ_DNLOAD	  0x01
+#define USB_DFU_REQ_UPLOAD	  0x02
+#define USB_DFU_REQ_GETSTATUS 0x03
+#define USB_DFU_REQ_CLRSTATUS 0x04
+#define USB_DFU_REQ_GETSTATE  0x05
+#define USB_DFU_REQ_ABORT	  0x06
+
+/* Run-Time DFU Functional Descriptor */
+struct usb_dfu_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bmAttributes;
+	uint16_t wDetachTimeOut;
+	uint16_t wTransferSize;
+	uint16_t bcdDFUVersion;
+}  __packed;
+
+/* DFU Functional Descriptor Type */
+#define USB_DESC_DFU_FUNCTIONAL 0x21
+
+/* DFU attributes DFU Functional Descriptor */
+#define USB_DFU_ATTR_WILL_DETACH			BIT(3)
+#define USB_DFU_ATTR_MANIFESTATION_TOLERANT BIT(2)
+#define USB_DFU_ATTR_CAN_UPLOAD				BIT(1)
+#define USB_DFU_ATTR_CAN_DNLOAD				BIT(0)
+
+/* DFU Specification release */
+#define USB_DFU_VERSION 0x0110
+
+/* DFU device status */
+enum usb_dfu_status {
+	ERR_OK          = 0x00,
+	ERR_TARGET      = 0x01,
+	ERR_FILE        = 0x02,
+	ERR_WRITE       = 0x03,
+	ERR_ERASE       = 0x04,
+	ERR_CHECK_ERASED    = 0x05,
+	ERR_PROG        = 0x06,
+	ERR_VERIFY      = 0x07,
+	ERR_ADDRESS     = 0x08,
+	ERR_NOTDONE     = 0x09,
+	ERR_FIRMWARE        = 0x0A,
+	ERR_VENDOR      = 0x0B,
+	ERR_USBR        = 0x0C,
+	ERR_POR         = 0x0D,
+	ERR_UNKNOWN     = 0x0E,
+	ERR_STALLEDPKT      = 0x0F,
+};
+
+/* DFU device states */
+enum usb_dfu_state {
+	APP_IDLE        = 0,
+	APP_DETACH      = 1,
+	DFU_IDLE        = 2,
+	DFU_DNLOAD_SYNC     = 3,
+	DFU_DNBUSY      = 4,
+	DFU_DNLOAD_IDLE     = 5,
+	DFU_MANIFEST_SYNC   = 6,
+	DFU_MANIFEST        = 7,
+	DFU_MANIFEST_WAIT_RST   = 8,
+	DFU_UPLOAD_IDLE     = 9,
+	DFU_ERROR       = 10,
+	DFU_STATE_MAX       = 11,
+};
+
+#endif /* ZEPHYR_INCLUDE_USB_CLASS_USBD_DFU_H */

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "can.h"
 #include "compiler.h"
 #include "config.h"
+#include "dfu.h"
 #include "gs_usb.h"
 #include "led.h"
 #include "list.h"
@@ -83,7 +84,23 @@ struct gs_host_frame_object {
 };
 
 typedef struct {
-	uint8_t __aligned(4) ep0_buf[GS_CAN_EP0_BUF_SIZE];
+	union {
+		struct_group_tagged(ep0, data, union {
+			// Device -> Host
+			struct dfu_status dfu_status;
+
+			// Host -> Device
+			const struct gs_host_config config;
+			const struct gs_device_bittiming bittiming;
+			const struct gs_device_mode mode;
+			const struct gs_identify_mode identify_mode;
+			const struct gs_device_filter filter;
+
+			// Device <-> Host
+			struct gs_device_termination_state term_state;
+		}; );
+		uint8_t buf[sizeof(struct ep0)];
+	} ep0;
 
 	USBD_SetupReqTypedef last_setup_request;
 

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -40,14 +40,6 @@ THE SOFTWARE.
 
 /* Define these here so they can be referenced in other files */
 
-#define GS_CAN_EP0_BUF_SIZE \
-		max6(sizeof(struct gs_host_config), \
-			 sizeof(struct gs_device_bittiming), \
-			 sizeof(struct gs_device_mode), \
-			 sizeof(struct gs_identify_mode), \
-			 sizeof(struct gs_device_termination_state), \
-			 sizeof(struct gs_device_filter))
-
 #ifdef CONFIG_CANFD
 #define CAN_DATA_MAX_PACKET_SIZE 64    /* Endpoint IN & OUT Packet size */
 #else

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -272,7 +272,7 @@ static uint8_t USBD_GS_CAN_DFU_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTy
 			hcan->dfu_detach_requested = true;
 			break;
 		case USB_DFU_REQ_GETSTATUS: {
-			struct dfu_status *status = (struct dfu_status *)hcan->ep0_buf;
+			struct dfu_status *status = &hcan->ep0.dfu_status;
 
 			status->status = ERR_OK;
 			status->poll_timeout[0] = 0x0;
@@ -281,7 +281,7 @@ static uint8_t USBD_GS_CAN_DFU_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTy
 			status->state = APP_IDLE;
 			status->stringidx = 0xff; // status string descriptor index
 
-			USBD_CtlSendData(pdev, hcan->ep0_buf, sizeof(struct dfu_status));
+			USBD_CtlSendData(pdev, hcan->ep0.buf, sizeof(struct dfu_status));
 			break;
 		}
 		default:
@@ -419,12 +419,12 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_DATA_BITTIMING:
 		case GS_USB_BREQ_SET_TERMINATION:
 		case GS_USB_BREQ_SET_FILTER:
-			if (req->wLength > sizeof(hcan->ep0_buf)) {
+			if (req->wLength > sizeof(hcan->ep0)) {
 				goto out_fail;
 			}
 
 			hcan->last_setup_request = *req;
-			USBD_CtlPrepareRx(pdev, hcan->ep0_buf, req->wLength);
+			USBD_CtlPrepareRx(pdev, hcan->ep0.buf, req->wLength);
 			break;
 
 		// Device -> Host
@@ -527,7 +527,7 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			break;
 
 		case GS_USB_BREQ_BITTIMING: {
-			const struct gs_device_bittiming *timing = (struct gs_device_bittiming *)hcan->ep0_buf;
+			const struct gs_device_bittiming *timing = &hcan->ep0.bittiming;
 
 			if (!can_check_bittiming_ok(&CAN_btconst.btc, timing))
 				goto out_fail;
@@ -536,9 +536,7 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			break;
 		}
 		case GS_USB_BREQ_MODE: {
-			struct gs_device_mode *mode;
-
-			mode = (struct gs_device_mode*)hcan->ep0_buf;
+			const struct gs_device_mode *mode = &hcan->ep0.mode;
 
 			if (mode->mode == GS_CAN_MODE_RESET) {
 				can_disable(channel);
@@ -554,9 +552,8 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			break;
 		}
 		case GS_USB_BREQ_IDENTIFY: {
-			struct gs_identify_mode *imode;
+			const struct gs_identify_mode *imode = &hcan->ep0.identify_mode;
 
-			imode = (struct gs_identify_mode *)hcan->ep0_buf;
 			if (imode->mode) {
 				led_run_sequence(&channel->leds, led_identify_seq, -1);
 			} else {
@@ -566,7 +563,7 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			break;
 		}
 		case GS_USB_BREQ_DATA_BITTIMING: {
-			const struct gs_device_bittiming *timing = (struct gs_device_bittiming *)hcan->ep0_buf;
+			const struct gs_device_bittiming *timing = &hcan->ep0.bittiming;
 
 			if (!can_check_bittiming_ok(&CAN_btconst_ext.dbtc, timing))
 				goto out_fail;
@@ -576,9 +573,8 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 		}
 		case GS_USB_BREQ_SET_TERMINATION: {
 			if (get_term(channel) != GS_CAN_TERMINATION_UNSUPPORTED) {
-				struct gs_device_termination_state *term_state;
+				const struct gs_device_termination_state *term_state = &hcan->ep0.term_state;
 
-				term_state = (struct gs_device_termination_state *)hcan->ep0_buf;
 				if (set_term(channel, term_state->state) == GS_CAN_TERMINATION_UNSUPPORTED) {
 					USBD_CtlError(pdev, req);
 				}
@@ -586,7 +582,7 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			break;
 		}
 		case GS_USB_BREQ_SET_FILTER: {
-			const struct gs_device_filter *filter = (struct gs_device_filter *)hcan->ep0_buf;
+			const struct gs_device_filter *filter = &hcan->ep0.filter;
 
 			if (!can_check_filter_ok(filter) || can_is_enabled(channel))
 				goto out_fail;

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "can_common.h"
 #include "compiler.h"
 #include "config.h"
+#include "dfu.h"
 #include "gpio.h"
 #include "gs_usb.h"
 #include "hal_include.h"
@@ -40,6 +41,7 @@ THE SOFTWARE.
 #include "usbd_ctlreq.h"
 #include "usbd_def.h"
 #include "usbd_desc.h"
+#include "usbd_dfu.h"
 #include "usbd_gs_can.h"
 #include "usbd_ioreq.h"
 #include "util.h"
@@ -263,27 +265,29 @@ static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 
 static uint8_t USBD_GS_CAN_DFU_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
-	switch (req->bRequest) {
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 
-		case 0: // DETACH request
+	switch (req->bRequest) {
+		case USB_DFU_REQ_DETACH:
 			hcan->dfu_detach_requested = true;
 			break;
+		case USB_DFU_REQ_GETSTATUS: {
+			struct dfu_status *status = (struct dfu_status *)hcan->ep0_buf;
 
-		case 3: // GET_STATUS request
-			hcan->ep0_buf[0] = 0x00; // bStatus: 0x00 == OK
-			hcan->ep0_buf[1] = 0x00; // bwPollTimeout
-			hcan->ep0_buf[2] = 0x00;
-			hcan->ep0_buf[3] = 0x00;
-			hcan->ep0_buf[4] = 0x00; // bState: appIDLE
-			hcan->ep0_buf[5] = 0xFF; // status string descriptor index
-			USBD_CtlSendData(pdev, hcan->ep0_buf, 6);
+			status->status = ERR_OK;
+			status->poll_timeout[0] = 0x0;
+			status->poll_timeout[1] = 0x0;
+			status->poll_timeout[2] = 0x0;
+			status->state = APP_IDLE;
+			status->stringidx = 0xff; // status string descriptor index
+
+			USBD_CtlSendData(pdev, hcan->ep0_buf, sizeof(struct dfu_status));
 			break;
-
+		}
 		default:
 			USBD_CtlError(pdev, req);
-
 	}
+
 	return USBD_OK;
 }
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -304,7 +304,6 @@ static can_data_t *USBD_GS_CAN_GetChannel(USBD_GS_CAN_HandleTypeDef *hcan,
 static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
-	struct gs_device_termination_state term_state;
 	can_data_t *channel = NULL;
 	const void *src = NULL;
 	size_t len;
@@ -384,16 +383,15 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			len = sizeof(struct gs_device_termination_state);
 			break;
 		case GS_USB_BREQ_GET_TERMINATION: {
-			enum gs_can_termination_state state;
+			struct gs_device_termination_state *term_state = &hcan->ep0.term_state;
 
-			state = get_term(channel);
-			if (state == GS_CAN_TERMINATION_UNSUPPORTED) {
+			term_state->state = get_term(channel);
+			if (term_state->state == GS_CAN_TERMINATION_UNSUPPORTED) {
 				goto out_fail;
 			}
 
-			term_state.state = state;
-			src = &term_state;
-			len = sizeof(term_state);
+			src = &hcan->ep0.term_state;
+			len = sizeof(*term_state);
 			break;
 		}
 		case GS_USB_BREQ_SET_FILTER:


### PR DESCRIPTION
using these `maxX` constructs is too error prone.