### PR TITLE
Rename TouCAN to FalCAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ set(TGTF042_LIST
 	"canalyze"
 	"cannette"
 	"cantact"
-	"toucan"
+	"falcan"
 	"usb2can"
 )
 set(TGTF072_LIST

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is firmware for certain STM32F042x/STM32F072xB-based USB-CAN adapters, nota
 - ConvertDevice-xCANFD: <https://github.com/ConvertDevice/xCANFD> (STM32G0B1CBT6)
 - DSD TECH SH-C30A: <https://www.deshide.com/product-details.html?pid=384242&_t=1671089557> (STM32F072xB)
 - FYSETC UCAN: <https://www.fysetc.com/products/fysetc-ucan-board-based-on-stm32f072-usb-to-can-adapter-support-with-canable-candlelight-klipper-firmware> (STM32F072xB)
-- TouCAN Probe <https://github.com/AndersBNielsen/TouCAN> (STM32F042C6)
+- FalCAN Probe: <https://github.com/AndersBNielsen/FalCAN> (STM32F042C6)
 
 Of important note is that the common STM32F103 will NOT work with this firmware because its hardware cannot use both USB and CAN simultaneously.
 Beware also the smaller packages in the F042 series which map a USB and CAN_TX signal on the same pin and are therefore unusable !

--- a/include/config.h
+++ b/include/config.h
@@ -148,10 +148,10 @@ THE SOFTWARE.
 	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
 	#define LEDTX_Active_High		 1
 
-#elif defined(BOARD_toucan)
-	#define USBD_PRODUCT_STRING_FS	 "TouCAN Probe gs_usb"
-	#define USBD_MANUFACTURER_STRING "TouCAN Probe"
-	#define DFU_INTERFACE_STRING_FS	 "TouCAN Probe firmware upgrade interface"
+#elif defined(BOARD_falcan)
+	#define USBD_PRODUCT_STRING_FS	 "FalCAN Probe gs_usb"
+	#define USBD_MANUFACTURER_STRING "FalCAN Probe"
+	#define DFU_INTERFACE_STRING_FS	 "FalCAN Probe firmware upgrade interface"
 
 	#define CONFIG_HSE_OSC_SPEED	 8000000
 	#define TIM2_CLOCK_SPEED		 48000000


### PR DESCRIPTION
Turns out the name TouCAN is taken by not just one other - but two - completely separate products, hence the rename from TouCAN to FalCAN.